### PR TITLE
Sql editor stretch

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
     "@jupyterlab/rendermime-interfaces": "^1.3.0",
     "@mapd/connector": "^4.6.1",
     "@phosphor/coreutils": "^1.3.1",
-    "@phosphor/datagrid": "^0.1.8",
+    "@phosphor/datagrid": "^0.2.0",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.8.0",
+    "@phosphor/widgets": "^1.9.0",
     "vega-lite": "3.4"
   },
   "devDependencies": {
@@ -67,6 +67,9 @@
       "prettier --write",
       "git add"
     ]
+  },
+  "resolutions": {
+    "@phosphor/widgets": "1.9.1"
   },
   "jupyterlab": {
     "extension": "lib/plugins",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -278,15 +278,15 @@ function activateOmniSciGridViewer(
   void restorer.restore(gridTracker, {
     command: CommandIDs.newGrid,
     args: widget => {
-      const con = widget.content.connectionData || {};
+      const con = widget.grid.connectionData || {};
       const connection = {
         host: con.host || '',
         protocol: con.protocol || '',
         port: con.port || ''
       };
-      const sessionId = widget.content.sessionId;
+      const sessionId = widget.grid.sessionId;
       return {
-        initialQuery: widget.content.query,
+        initialQuery: widget.grid.query,
         connectionData: connection,
         sessionId: sessionId || null
       };
@@ -297,24 +297,24 @@ function activateOmniSciGridViewer(
   // Create a completion handler for each grid that is created.
   gridTracker.widgetAdded.connect((sender, explorer) => {
     const editor = explorer.input.editor;
-    const sessionId = explorer.content.sessionId;
+    const sessionId = explorer.grid.sessionId;
     const connector = new OmniSciCompletionConnector({
-      connection: explorer.content.connectionData,
+      connection: explorer.grid.connectionData,
       sessionId
     });
     const parent = explorer;
     const handle = completionManager.register({ connector, editor, parent });
 
-    explorer.content.onModelChanged.connect(() => {
-      const sessionId = explorer.content.sessionId;
+    explorer.grid.onModelChanged.connect(() => {
+      const sessionId = explorer.grid.sessionId;
       handle.connector = new OmniSciCompletionConnector({
-        connection: explorer.content.connectionData,
+        connection: explorer.grid.connectionData,
         sessionId
       });
     });
     // Set the theme for the new widget.
-    explorer.content.style = style;
-    explorer.content.renderer = renderer;
+    explorer.grid.style = style;
+    explorer.grid.renderer = renderer;
   });
 
   // The current styles for the data grids.
@@ -329,8 +329,8 @@ function activateOmniSciGridViewer(
     style = isLight ? Private.LIGHT_STYLE : Private.DARK_STYLE;
     renderer = isLight ? Private.LIGHT_RENDERER : Private.DARK_RENDERER;
     gridTracker.forEach(grid => {
-      grid.content.style = style;
-      grid.content.renderer = renderer;
+      grid.grid.style = style;
+      grid.grid.renderer = renderer;
     });
     mimeGridTracker.forEach((mimeGrid: any) => {
       mimeGrid.widget.content.style = style;
@@ -356,24 +356,24 @@ function activateOmniSciGridViewer(
   // completions and theming.
   mimeGridTracker.widgetAdded.connect((sender, mime) => {
     const grid = mime.widget;
-    const sessionId = grid.content.sessionId;
+    const sessionId = grid.grid.sessionId;
     const editor = grid.input.editor;
     const connector = new OmniSciCompletionConnector({
-      connection: grid.content.connectionData,
+      connection: grid.grid.connectionData,
       sessionId
     });
     const parent = mime;
     const handle = completionManager.register({ connector, editor, parent });
 
-    grid.content.onModelChanged.connect(() => {
-      const sessionId = grid.content.sessionId;
+    grid.grid.onModelChanged.connect(() => {
+      const sessionId = grid.grid.sessionId;
       handle.connector = new OmniSciCompletionConnector({
-        connection: grid.content.connectionData,
+        connection: grid.grid.connectionData,
         sessionId
       });
     });
-    mime.widget.content.style = style;
-    mime.widget.content.renderer = renderer;
+    mime.widget.grid.style = style;
+    mime.widget.grid.renderer = renderer;
   });
 
   // Add grid completer command.
@@ -451,7 +451,7 @@ function activateOmniSciGridViewer(
       void gridTracker.add(grid);
       app.shell.add(grid, 'main');
       app.shell.activateById(grid.id);
-      grid.content.onModelChanged.connect(() => {
+      grid.grid.onModelChanged.connect(() => {
         void gridTracker.save(grid);
       });
       return grid;
@@ -470,8 +470,8 @@ function activateOmniSciGridViewer(
   manager.changed.connect(() => {
     const defaultConnectionData = manager.defaultConnection;
     gridTracker.forEach(grid => {
-      if (!grid.content.connectionData) {
-        void grid.content.setConnectionData(defaultConnectionData);
+      if (!grid.grid.connectionData) {
+        void grid.grid.setConnectionData(defaultConnectionData);
       }
     });
   });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,7 @@ import { IEditorServices } from '@jupyterlab/codeeditor';
 
 import { ICompletionManager } from '@jupyterlab/completer';
 
-import { ISettingRegistry, IStateDB, URLExt } from '@jupyterlab/coreutils';
+import { ISettingRegistry, URLExt } from '@jupyterlab/coreutils';
 
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 
@@ -251,7 +251,6 @@ const omnisciGridPlugin: JupyterFrontEndPlugin<void> = {
     ILayoutRestorer,
     IMainMenu,
     IOmniSciConnectionManager,
-    IStateDB,
     IThemeManager
   ],
   autoStart: true
@@ -265,7 +264,6 @@ function activateOmniSciGridViewer(
   restorer: ILayoutRestorer,
   mainMenu: IMainMenu,
   manager: IOmniSciConnectionManager,
-  state: IStateDB,
   themeManager: IThemeManager
 ): void {
   const gridNamespace = 'omnisci-grid-widget';
@@ -450,6 +448,7 @@ function activateOmniSciGridViewer(
       grid.title.closable = true;
       grid.title.iconClass = 'omnisci-OmniSci-logo';
       const main = new MainAreaWidget({ content: grid });
+      main.id = grid.id;
       void gridTracker.add(main);
       app.shell.add(main, 'main');
       app.shell.activateById(main.id);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -317,7 +317,7 @@ function activateOmniSciGridViewer(
   });
 
   // The current styles for the data grids.
-  let style: DataGrid.IStyle = Private.LIGHT_STYLE;
+  let style: DataGrid.Style = Private.LIGHT_STYLE;
   let renderer: TextRenderer = Private.LIGHT_RENDERER;
 
   // Keep the themes up-to-date.
@@ -699,25 +699,45 @@ namespace Private {
   /**
    * The light theme for the data grid.
    */
-  export const LIGHT_STYLE: DataGrid.IStyle = {
+  export const LIGHT_STYLE: DataGrid.Style = {
     ...DataGrid.defaultStyle,
     voidColor: '#F3F3F3',
     backgroundColor: 'white',
     headerBackgroundColor: '#EEEEEE',
     gridLineColor: 'rgba(20, 20, 20, 0.15)',
     headerGridLineColor: 'rgba(20, 20, 20, 0.25)',
-    rowBackgroundColor: i => (i % 2 === 0 ? '#F5F5F5' : 'white')
+    rowBackgroundColor: i => (i % 2 === 0 ? '#F5F5F5' : 'white'),
+    selectionFillColor: 'rgba(49, 119, 229, 0.2)',
+    selectionBorderColor: 'rgba(0, 107, 247, 1.0)',
+    cursorBorderColor: 'rgba(0, 107, 247, 1.0)',
+    headerSelectionFillColor: 'rgba(20, 20, 20, 0.1)',
+    scrollShadow: {
+      size: 10,
+      color1: 'rgba(0, 0, 0, 0.20)',
+      color2: 'rgba(0, 0, 0, 0.05)',
+      color3: 'rgba(0, 0, 0, 0.00)'
+    }
   };
   /**
    * The dark theme for the data grid.
    */
-  export const DARK_STYLE: DataGrid.IStyle = {
+  export const DARK_STYLE: DataGrid.Style = {
     voidColor: 'black',
     backgroundColor: '#111111',
     headerBackgroundColor: '#424242',
     gridLineColor: 'rgba(235, 235, 235, 0.15)',
     headerGridLineColor: 'rgba(235, 235, 235, 0.25)',
-    rowBackgroundColor: i => (i % 2 === 0 ? '#212121' : '#111111')
+    rowBackgroundColor: i => (i % 2 === 0 ? '#212121' : '#111111'),
+    selectionFillColor: 'rgba(49, 119, 229, 0.2)',
+    selectionBorderColor: 'rgba(0, 107, 247, 1.0)',
+    cursorBorderColor: 'rgba(0, 107, 247, 1.0)',
+    headerSelectionFillColor: 'rgba(20, 20, 20, 0.2)',
+    scrollShadow: {
+      size: 10,
+      color1: 'rgba(0, 0, 0, 0.20)',
+      color2: 'rgba(0, 0, 0, 0.05)',
+      color3: 'rgba(0, 0, 0, 0.00)'
+    }
   };
   /**
    * The light renderer for the data grid.

--- a/src/grid.ts
+++ b/src/grid.ts
@@ -6,6 +6,7 @@ import { Message } from '@phosphor/messaging';
 
 import {
   Panel,
+  PanelLayout,
   SplitLayout,
   SplitPanel,
   StackedPanel,
@@ -14,7 +15,7 @@ import {
 
 import { ISignal, Signal } from '@phosphor/signaling';
 
-import { MainAreaWidget, Toolbar, ToolbarButton } from '@jupyterlab/apputils';
+import { MainAreaWidget, ToolbarButton } from '@jupyterlab/apputils';
 
 import { CodeEditor, CodeEditorWrapper } from '@jupyterlab/codeeditor';
 
@@ -57,7 +58,7 @@ export class OmniSciSQLEditor extends MainAreaWidget<Widget> {
     (content.layout as SplitLayout).addWidget(toolbar);
     (content.layout as SplitLayout).addWidget(grid);
     super({ content });
-    content.setRelativeSizes([0.15, 0.85]);
+    content.setRelativeSizes([0.1, 0.9]);
     this._grid = grid;
     this._tool = toolbar;
     this.addClass('omnisci-OmniSciSQLEditor');
@@ -134,7 +135,7 @@ export class OmniSciSQLEditor extends MainAreaWidget<Widget> {
   }
 
   private _grid: OmniSciGrid;
-  private _tool: Toolbar;
+  private _tool: Panel;
 }
 
 /**
@@ -699,8 +700,8 @@ namespace Private {
     widget: OmniSciGrid,
     editorFactory: CodeEditor.Factory,
     manager?: IOmniSciConnectionManager
-  ): Toolbar {
-    const toolbar = new Toolbar();
+  ): Panel {
+    const toolbar = new Panel();
     toolbar.addClass('omnisci-OmniSci-toolbar');
 
     // Create the query editor.
@@ -713,9 +714,8 @@ namespace Private {
     queryEditor.editor.model.mimeType = 'text/x-sql';
 
     // Create the toolbar.
-    toolbar.addItem('QueryInput', queryEditor);
-    toolbar.addItem(
-      'Query',
+    (toolbar.layout as PanelLayout).addWidget(queryEditor);
+    (toolbar.layout as PanelLayout).addWidget(
       new ToolbarButton({
         iconClassName: 'jp-RunIcon jp-Icon jp-Icon-16',
         onClick: () => {
@@ -725,8 +725,7 @@ namespace Private {
       })
     );
     if (manager) {
-      toolbar.addItem(
-        'Connect',
+      (toolbar.layout as PanelLayout).addWidget(
         new ToolbarButton({
           iconClassName: 'omnisci-OmniSci-logo jp-Icon jp-Icon-16',
           onClick: () => {

--- a/src/grid.ts
+++ b/src/grid.ts
@@ -1,6 +1,13 @@
 import { JSONExt, JSONObject } from '@phosphor/coreutils';
 
-import { DataGrid, DataModel, TextRenderer } from '@phosphor/datagrid';
+import {
+  BasicKeyHandler,
+  BasicMouseHandler,
+  BasicSelectionModel,
+  DataGrid,
+  DataModel,
+  TextRenderer
+} from '@phosphor/datagrid';
 
 import { Message } from '@phosphor/messaging';
 
@@ -208,19 +215,26 @@ export class OmniSciGrid extends Panel {
       textColor: '#111111',
       horizontalAlignment: 'right'
     });
-    const gridStyle: DataGrid.IStyle = {
+    const gridStyle: DataGrid.Style = {
       ...DataGrid.defaultStyle,
       rowBackgroundColor: i => (i % 2 === 0 ? 'rgba(34, 167, 240, 0.2)' : '')
     };
     this._grid = new DataGrid({
       style: gridStyle,
-      baseRowSize: 24,
-      baseColumnSize: 144,
-      baseColumnHeaderSize: 36,
-      baseRowHeaderSize: 64
+      defaultSizes: {
+        rowHeight: 24,
+        columnWidth: 144,
+        rowHeaderWidth: 64,
+        columnHeaderHeight: 36
+      }
     });
     this._grid.defaultRenderer = renderer;
-    this._grid.model = this._model;
+    this._grid.dataModel = this._model;
+    this._grid.mouseHandler = new BasicMouseHandler();
+    this._grid.keyHandler = new BasicKeyHandler();
+    this._grid.selectionModel = new BasicSelectionModel({
+      dataModel: this._model
+    });
     this._content.addWidget(this._grid);
     this._content.hide(); // Initially hide the grid until we set the query.
 
@@ -248,10 +262,10 @@ export class OmniSciGrid extends Panel {
   /**
    * The current style used by the grid viewer.
    */
-  get style(): DataGrid.IStyle {
+  get style(): DataGrid.Style {
     return this._grid.style;
   }
-  set style(value: DataGrid.IStyle) {
+  set style(value: DataGrid.Style) {
     this._grid.style = value;
   }
 
@@ -608,8 +622,8 @@ export class OmniSciTableModel extends DataModel {
       this.emitChanged({
         type: 'cells-changed',
         region: 'body',
-        rowIndex: offset,
-        columnIndex: 0,
+        row: offset,
+        column: 0,
         rowSpan: res.results.length,
         columnSpan: this._fieldNames.length
       });
@@ -643,8 +657,8 @@ export class OmniSciTableModel extends DataModel {
     this.emitChanged({
       type: 'cells-changed',
       region: 'body',
-      rowIndex: offset,
-      columnIndex: 0,
+      row: offset,
+      column: 0,
       rowSpan: length,
       columnSpan: this._fieldNames.length
     });
@@ -671,8 +685,8 @@ export class OmniSciTableModel extends DataModel {
       this.emitChanged({
         type: 'cells-changed',
         region: 'body',
-        rowIndex: 0,
-        columnIndex: 0,
+        row: 0,
+        column: 0,
         rowSpan: res.results.length,
         columnSpan: this._fieldNames.length
       });

--- a/src/grid.ts
+++ b/src/grid.ts
@@ -7,7 +7,6 @@ import { Message } from '@phosphor/messaging';
 import {
   Panel,
   PanelLayout,
-  SplitLayout,
   SplitPanel,
   StackedPanel,
   Widget
@@ -15,7 +14,7 @@ import {
 
 import { ISignal, Signal } from '@phosphor/signaling';
 
-import { MainAreaWidget, ToolbarButton } from '@jupyterlab/apputils';
+import { ToolbarButton } from '@jupyterlab/apputils';
 
 import { CodeEditor, CodeEditorWrapper } from '@jupyterlab/codeeditor';
 
@@ -36,15 +35,17 @@ const BLOCK_SIZE = 50000;
  */
 const DEFAULT_LIMIT = 50000;
 
-export class OmniSciSQLEditor extends MainAreaWidget<Widget> {
+export class OmniSciSQLEditor extends Panel {
   /**
    * Construct a new OmniSciSQLEditor widget.
    */
   constructor(options: OmniSciSQLEditor.IOptions) {
+    super();
+    const content = new SplitPanel({ orientation: 'vertical', spacing: 2 });
+    this.addWidget(content);
     const connection =
       options.connectionData ||
       (options.manager && options.manager.defaultConnection);
-    const content = new SplitPanel({ orientation: 'vertical', spacing: 0 });
     const grid = new OmniSciGrid({
       connectionData: connection,
       sessionId: options.sessionId,
@@ -55,10 +56,9 @@ export class OmniSciSQLEditor extends MainAreaWidget<Widget> {
       options.editorFactory,
       options.manager
     );
-    (content.layout as SplitLayout).addWidget(toolbar);
-    (content.layout as SplitLayout).addWidget(grid);
-    super({ content });
-    content.setRelativeSizes([0.1, 0.9]);
+    content.addWidget(toolbar);
+    content.addWidget(grid);
+    this._content = content;
     this._grid = grid;
     this._tool = toolbar;
     this.addClass('omnisci-OmniSciSQLEditor');
@@ -111,6 +111,10 @@ export class OmniSciSQLEditor extends MainAreaWidget<Widget> {
    */
   protected onAfterAttach(msg: Message): void {
     this.input.node.addEventListener('keydown', this, true);
+    requestAnimationFrame(() => {
+      this._content.setRelativeSizes([1, 6]);
+    });
+    super.onAfterAttach(msg);
   }
 
   /**
@@ -118,6 +122,7 @@ export class OmniSciSQLEditor extends MainAreaWidget<Widget> {
    */
   protected onBeforeDetach(msg: Message): void {
     this.input.node.removeEventListener('keydown', this, true);
+    super.onBeforeDetach(msg);
   }
 
   /**
@@ -125,6 +130,7 @@ export class OmniSciSQLEditor extends MainAreaWidget<Widget> {
    */
   protected onActivateRequest(msg: Message): void {
     this._focusInput();
+    super.onActivateRequest(msg);
   }
 
   /**
@@ -134,6 +140,7 @@ export class OmniSciSQLEditor extends MainAreaWidget<Widget> {
     this.input.activate();
   }
 
+  private _content: SplitPanel;
   private _grid: OmniSciGrid;
   private _tool: Panel;
 }

--- a/src/grid.ts
+++ b/src/grid.ts
@@ -93,9 +93,11 @@ export class OmniSciSQLEditor extends Panel {
       case 'keydown':
         switch (event.keyCode) {
           case 13: // Enter
-            event.stopPropagation();
-            event.preventDefault();
-            this._grid.query = this.input.editor.model.value.text;
+            if (event.shiftKey) {
+              event.stopPropagation();
+              event.preventDefault();
+              this._grid.query = this.input.editor.model.value.text;
+            }
             break;
           default:
             break;

--- a/src/mimeextensions.ts
+++ b/src/mimeextensions.ts
@@ -159,11 +159,8 @@ export class RenderedOmniSciSQLEditor extends Widget
     if (!data) {
       return Promise.resolve(void 0);
     }
-    await this._widget.content.setConnectionData(
-      data.connection,
-      data.sessionId
-    );
-    this._widget.content.query = data.query || '';
+    await this._widget.grid.setConnectionData(data.connection, data.sessionId);
+    this._widget.grid.query = data.query || '';
     return Promise.resolve(void 0);
   }
 

--- a/style/index.css
+++ b/style/index.css
@@ -1,5 +1,4 @@
 :root {
-  --omnisci-sqleditor-toolbar-height: calc(72px + var(--jp-border-width));
   --omnisci-vega-toolbar-height: calc(36px + var(--jp-border-width));
 }
 
@@ -20,11 +19,6 @@
   overflow: auto;
 }
 
-.omnisci-OmniSciGrid {
-  top: var(--omnisci-sqleditor-toolbar-height) !important;
-  height: calc(100% - var(--omnisci-sqleditor-toolbar-height)) !important;
-}
-
 .omnisci-OmniSciGrid-content {
   height: 100%;
 }
@@ -33,17 +27,10 @@
   min-height: 512px;
 }
 
-.jp-Notebook .jp-Cell .jp-OutputArea .omnisci-OmniSciGrid-content {
-  height: calc(100% - var(--omnisci-sqleditor-toolbar-height)) !important;
-}
-
 .jp-Toolbar.omnisci-OmniSci-toolbar {
   justify-content: right;
   align-items: center;
-}
-
-.omnisci-OmniSciSQLEditor .jp-Toolbar.omnisci-OmniSci-toolbar {
-  height: var(--omnisci-sqleditor-toolbar-height) !important;
+  padding: 12px;
 }
 
 .omnisci-OmniSciVegaViewer .jp-Toolbar.omnisci-OmniSci-toolbar {
@@ -60,7 +47,7 @@
   font-family: monospace;
   background-color: var(--jp-layout-color0);
   border: var(--jp-border-width) solid var(--jp-border-color0);
-  margin-left: 12px;
+  height: 100%;
 }
 
 .jp-Toolbar.omnisci-OmniSci-toolbar .jp-Editor.jp-mod-focused {

--- a/style/index.css
+++ b/style/index.css
@@ -24,8 +24,20 @@
   height: 100%;
 }
 
-.jp-Notebook .jp-Cell .jp-OutputArea .omnisci-OmniSciGrid {
-  min-height: 512px;
+.omnisci-RenderedOmniSciSQLEditor .omnisci-OmniSciSQLEditor {
+  height: 100%;
+}
+
+.jp-Cell .jp-OutputArea-output.omnisci-RenderedOmniSciSQLEditor {
+  min-height: calc(384px + var(--omnisci-sqleditor-toolbar-min-height));
+}
+
+.omnisci-OmniSciSQLEditor .p-SplitPanel {
+  height: 100%;
+}
+
+.omnisci-OmniSciGrid {
+  min-height: 128px;
 }
 
 .omnisci-OmniSci-toolbar {

--- a/style/index.css
+++ b/style/index.css
@@ -1,5 +1,6 @@
 :root {
   --omnisci-vega-toolbar-height: calc(36px + var(--jp-border-width));
+  --omnisci-sqleditor-toolbar-min-height: 52px;
 }
 
 .omnisci-ErrorMessage {
@@ -27,21 +28,28 @@
   min-height: 512px;
 }
 
-.jp-Toolbar.omnisci-OmniSci-toolbar {
+.omnisci-OmniSci-toolbar {
   justify-content: right;
   align-items: center;
   padding: 12px;
+  display: flex;
+  flex-direction: row;
+  color: var(--jp-ui-font-color1);
+  border-bottom: var(--jp-border-width) solid var(--jp-toolbar-border-color);
+  box-shadow: var(--jp-toolbar-box-shadow);
+  background: var(--jp-toolbar-background);
+  min-height: var(--omnisci-sqleditor-toolbar-min-height);
 }
 
 .omnisci-OmniSciVegaViewer .jp-Toolbar.omnisci-OmniSci-toolbar {
   height: var(--omnisci-vega-toolbar-height) !important;
 }
 
-.jp-Toolbar.omnisci-OmniSci-toolbar .jp-Toolbar-item {
+.omnisci-OmniSci-toolbar .jp-Toolbar-item {
   height: auto;
 }
 
-.jp-Toolbar.omnisci-OmniSci-toolbar .jp-Editor {
+.omnisci-OmniSci-toolbar .jp-Editor {
   flex: 1 1 auto;
   font-size: 1em;
   font-family: monospace;
@@ -50,13 +58,13 @@
   height: 100%;
 }
 
-.jp-Toolbar.omnisci-OmniSci-toolbar .jp-Editor.jp-mod-focused {
+.omnisci-OmniSci-toolbar .jp-Editor.jp-mod-focused {
   border: var(--jp-border-width) solid var(--jp-cell-editor-active-border-color);
   box-shadow: var(--jp-input-box-shadow);
   background-color: var(--jp-cell-editor-active-background);
 }
 
-.jp-Toolbar.omnisci-OmniSci-toolbar .jp-Editor .CodeMirror {
+.omnisci-OmniSci-toolbar .jp-Editor .CodeMirror {
   width: 100%;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -447,24 +447,36 @@
     "@phosphor/keyboard" "^1.1.3"
     "@phosphor/signaling" "^1.3.0"
 
+"@phosphor/commands@^1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@phosphor/commands/-/commands-1.7.1.tgz#be022b63f454a9c6d5f677066d85007c2cd632d4"
+  integrity sha512-KELPYLrNLVkMA5XntDogQkKXWbhLhpjxLBD75faywoe4GCyVsm//CA7Wn50+eVo0pI87z27Qbtzo0TR6NH4Jvw==
+  dependencies:
+    "@phosphor/algorithm" "^1.2.0"
+    "@phosphor/coreutils" "^1.3.1"
+    "@phosphor/disposable" "^1.3.0"
+    "@phosphor/domutils" "^1.1.4"
+    "@phosphor/keyboard" "^1.1.3"
+    "@phosphor/signaling" "^1.3.0"
+
 "@phosphor/coreutils@^1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@phosphor/coreutils/-/coreutils-1.3.1.tgz#441e34f42340f7faa742a88b2a181947a88d7226"
   integrity sha512-9OHCn8LYRcPU/sbHm5v7viCA16Uev3gbdkwqoQqlV+EiauDHl70jmeL7XVDXdigl66Dz0LI11C99XOxp+s3zOA==
 
-"@phosphor/datagrid@^0.1.8":
-  version "0.1.11"
-  resolved "https://registry.yarnpkg.com/@phosphor/datagrid/-/datagrid-0.1.11.tgz#ebf884ec506f7a875df94abc57aa5a5bdae369fa"
-  integrity sha512-mGJDbkYx5Wd4X4SO8FO+IHY3bq2ukx63/Fk98AZbunzLO2BgM22c60j/h8KS/nFAThJC0pDB4isG6w3Z62f/Zw==
+"@phosphor/datagrid@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@phosphor/datagrid/-/datagrid-0.2.0.tgz#6d6be6e852c61429711f0ab179128dca9e4198bd"
+  integrity sha512-3uBpzhjq9yC8+r/NK6VA6jg6H8uzPGBYp8dyYg+59UZkDA6bVjEmDlUZ31qIhi+4GgDW1DZ94BNs08EMBw8+Xw==
   dependencies:
     "@phosphor/algorithm" "^1.2.0"
     "@phosphor/coreutils" "^1.3.1"
     "@phosphor/disposable" "^1.3.0"
-    "@phosphor/domutils" "^1.1.3"
+    "@phosphor/domutils" "^1.1.4"
     "@phosphor/dragdrop" "^1.4.0"
     "@phosphor/messaging" "^1.3.0"
     "@phosphor/signaling" "^1.3.0"
-    "@phosphor/widgets" "^1.9.0"
+    "@phosphor/widgets" "^1.9.1"
 
 "@phosphor/disposable@^1.2.0", "@phosphor/disposable@^1.3.0":
   version "1.3.0"
@@ -478,6 +490,11 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@phosphor/domutils/-/domutils-1.1.3.tgz#5aeeaefb4bbfcc7c0942e5287a29d3c7f2b1a2bc"
   integrity sha512-5CtLAhURQXXHhNXfQydDk/luG1cDVnhlu/qw7gz8/9pht0KXIAmNg/M0LKxx2oJ9+YMNCLVWxAnHAU0yrDpWSA==
+
+"@phosphor/domutils@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@phosphor/domutils/-/domutils-1.1.4.tgz#4c6aecf7902d3793b45db325319340e0a0b5543b"
+  integrity sha512-ivwq5TWjQpKcHKXO8PrMl+/cKqbgxPClPiCKc1gwbMd+6hnW5VLwNG0WBzJTxCzXK43HxX18oH+tOZ3E04wc3w==
 
 "@phosphor/dragdrop@^1.3.3", "@phosphor/dragdrop@^1.4.0":
   version "1.4.0"
@@ -519,16 +536,16 @@
   dependencies:
     "@phosphor/algorithm" "^1.2.0"
 
-"@phosphor/widgets@^1.8.0", "@phosphor/widgets@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@phosphor/widgets/-/widgets-1.9.0.tgz#fd234cf3c515aaa7a072e9c62eecf7416f703fc7"
-  integrity sha512-Op6H0lI7MlHAs+htzy+6fL+x3TxG0N024RGsdIYkaNKyeSw6b7ZUXcd7mKCeabWPoTwiMCx3kiLTvExmNSYgwA==
+"@phosphor/widgets@1.9.1", "@phosphor/widgets@^1.8.0", "@phosphor/widgets@^1.9.0", "@phosphor/widgets@^1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@phosphor/widgets/-/widgets-1.9.1.tgz#9016fc542ba63e99166e90354c3a3c2cf731b90d"
+  integrity sha512-jA2GgyJfz9omFZaTzGRCRPuT91CAFcLKtUVqq5N5nEzT53nzq+tKgqw9AXOyAjxGqp8IffL6QVCKpl50KPQy0g==
   dependencies:
     "@phosphor/algorithm" "^1.2.0"
-    "@phosphor/commands" "^1.7.0"
+    "@phosphor/commands" "^1.7.1"
     "@phosphor/coreutils" "^1.3.1"
     "@phosphor/disposable" "^1.3.0"
-    "@phosphor/domutils" "^1.1.3"
+    "@phosphor/domutils" "^1.1.4"
     "@phosphor/dragdrop" "^1.4.0"
     "@phosphor/keyboard" "^1.1.3"
     "@phosphor/messaging" "^1.3.0"


### PR DESCRIPTION
This adds two significant usability improvements to the JupyterLab OmniSci SQL editor.
1. It previously didn't work very well with longer SQL queries, as they would run off the edge of the editor, to the point where the user couldn't see them. This makes the editor properly scrollable, and the size of the toolbar can be expanded and collapsed using a split panel. As a result of this change, I have made the "execute" keyboard shortcut `Shift+Enter`, so that the user can more easily enter line breaks. This is also more consistent with users' notebook muscle memory.
2. The upstream datagrid package now supports selections and copy/paste (as of this morning!). I have updated to use that, and now the user can copy/paste out of the grid results. Currently, the paste buffer gets TSV, but we could customize the selection model to get CSV or HTML tables (cc. @randyzwitch). So this PR more-or-less fixes #20.
![stretch](https://user-images.githubusercontent.com/5728311/64464456-e2434800-d0bc-11e9-8955-7e594fec3564.gif)

